### PR TITLE
Refine response_schema typing

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,12 +1,18 @@
 import asyncio
-
-import streamlit as st
 from datetime import datetime
 
-from src.celeste_structured_output import StructuredOutputProvider, create_structured_client
-from src.celeste_structured_output.core.enums import GoogleStructuredModel, OpenAIStructuredModel
+import streamlit as st
 
-st.title('Celeste Structured output')
+from src.celeste_structured_output import (
+    StructuredOutputProvider,
+    create_structured_client,
+)
+from src.celeste_structured_output.core.enums import (
+    GoogleStructuredModel,
+    OpenAIStructuredModel,
+)
+
+st.title("Celeste Structured output")
 
 PROVIDER_MODEL_MAP = {
     StructuredOutputProvider.GOOGLE.name: GoogleStructuredModel,
@@ -18,17 +24,17 @@ with st.sidebar:
         "Select provider",
         [p.name for p in list(StructuredOutputProvider)],
         format_func=lambda x: StructuredOutputProvider[x].name,
-        key="provider"
+        key="provider",
     )
 
     structured_output_model = st.selectbox(
         "Select model",
         [m.name for m in PROVIDER_MODEL_MAP[structured_output_provider]],
-        key="model"
+        key="model",
     )
 
 # Initialize session state for properties
-if 'properties' not in st.session_state:
+if "properties" not in st.session_state:
     st.session_state.properties = []
 
 # Structure Builder
@@ -45,37 +51,56 @@ if st.button("Add Property"):
     st.session_state.properties.append({"name": "", "type": "str"})
 
 # Display properties
-for i, prop in enumerate(st.session_state.properties):
+for i, _prop in enumerate(st.session_state.properties):
     col1, col2 = st.columns(2)
     with col1:
-        st.session_state.properties[i]["name"] = st.text_input(f"Property name", key=f"name_{i}")
+        st.session_state.properties[i]["name"] = st.text_input(
+            "Property name",
+            key=f"name_{i}",
+        )
     with col2:
-        st.session_state.properties[i]["type"] = st.selectbox("Type", ["str", "int", "datetime"], key=f"type_{i}")
+        st.session_state.properties[i]["type"] = st.selectbox(
+            "Type",
+            ["str", "int", "datetime"],
+            key=f"type_{i}",
+        )
 
 model_enum = PROVIDER_MODEL_MAP[structured_output_provider]
 client = create_structured_client(
     provider=StructuredOutputProvider[structured_output_provider].value,
-    model=model_enum[structured_output_model].value
+    model=model_enum[structured_output_model].value,
 )
 
 prompt = st.text_input("Prompt", value=f"Generate a sample {structure_name}")
 
 if st.button("Generate"):
     # Create dynamic model from properties
+
     from pydantic import create_model
-    from typing import List
-    
+
     fields = {}
     for prop in st.session_state.properties:
         if prop["name"]:
-            field_type = {"str": str, "int": int, "datetime": datetime}[prop["type"]]
+            field_type = {
+                "str": str,
+                "int": int,
+                "datetime": datetime,
+            }[prop["type"]]
             fields[prop["name"]] = (field_type, ...)
+
     DynamicModel = create_model(structure_name, **fields)
-    
+
     # Use list schema if requested
-    response_schema = list[DynamicModel] if return_type == "List of objects" else DynamicModel
-    
+    response_schema = (
+        list[DynamicModel] if return_type == "List of objects" else DynamicModel
+    )
+
     with st.spinner("Generating..."):
-        output = asyncio.run(client.generate_content(prompt=prompt, response_schema=response_schema))
+        output = asyncio.run(
+            client.generate_content(
+                prompt=prompt,
+                response_schema=response_schema,
+            )
+        )
         if output:
             st.json(output.content)

--- a/src/celeste_structured_output/__init__.py
+++ b/src/celeste_structured_output/__init__.py
@@ -5,12 +5,14 @@ Celeste AI Client - Minimal predefinition AI communication for Alita agents.
 from typing import Any, Union
 
 from .base import BaseStructuredClient
-from .core import StructuredResponse, StructuredOutputProvider
+from .core import StructuredOutputProvider, StructuredResponse
 
 __version__ = "0.1.0"
 
 
-def create_structured_client(provider: Union[StructuredOutputProvider, str], **kwargs: Any) -> BaseStructuredClient:
+def create_structured_client(
+    provider: Union[StructuredOutputProvider, str], **kwargs: Any
+) -> BaseStructuredClient:
     if isinstance(provider, str):
         provider = StructuredOutputProvider(provider)
 
@@ -41,5 +43,5 @@ __all__ = [
     "create_structured_client",
     "BaseStructuredClient",
     "StructuredOutputProvider",
-    "StructuredResponse"
+    "StructuredResponse",
 ]

--- a/src/celeste_structured_output/base.py
+++ b/src/celeste_structured_output/base.py
@@ -17,14 +17,20 @@ class BaseStructuredClient(ABC):
 
     @abstractmethod
     async def generate_content(
-        self, prompt: str, response_schema: BaseModel, **kwargs: Any
+        self,
+        prompt: str,
+        response_schema: Optional[type[BaseModel]] = None,
+        **kwargs: Any,
     ) -> StructuredResponse:
         """Generates a single response."""
         pass
 
     @abstractmethod
     async def stream_generate_content(
-        self, prompt: str, response_schema: BaseModel, **kwargs: Any
+        self,
+        prompt: str,
+        response_schema: Optional[type[BaseModel]] = None,
+        **kwargs: Any,
     ) -> AsyncIterator[StructuredResponse]:
         """Streams the response chunk by chunk."""
         pass

--- a/src/celeste_structured_output/providers/google.py
+++ b/src/celeste_structured_output/providers/google.py
@@ -6,12 +6,14 @@ from pydantic import BaseModel
 
 from ..base import BaseStructuredClient
 from ..core.config import GOOGLE_API_KEY
-from ..core.enums import StructuredOutputProvider, GoogleStructuredModel
-from ..core.types import StructuredResponse, AIUsage
+from ..core.enums import GoogleStructuredModel, StructuredOutputProvider
+from ..core.types import AIUsage, StructuredResponse
 
 
 class GoogleStructuredClient(BaseStructuredClient):
-    def __init__(self, model: str = GoogleStructuredModel.FLASH_LITE, **kwargs: Any) -> None:
+    def __init__(
+        self, model: str = GoogleStructuredModel.FLASH_LITE, **kwargs: Any
+    ) -> None:
         super().__init__(**kwargs)
 
         self.client = genai.Client(api_key=GOOGLE_API_KEY)
@@ -28,7 +30,10 @@ class GoogleStructuredClient(BaseStructuredClient):
         )
 
     async def generate_content(
-        self, prompt: str, response_schema: BaseModel, **kwargs: Any
+        self,
+        prompt: str,
+        response_schema: type[BaseModel],
+        **kwargs: Any,
     ) -> StructuredResponse:
         config = kwargs.pop("config", {})
 
@@ -57,7 +62,10 @@ class GoogleStructuredClient(BaseStructuredClient):
         )
 
     async def stream_generate_content(
-        self, prompt: str, response_schema: BaseModel, **kwargs: Any
+        self,
+        prompt: str,
+        response_schema: type[BaseModel],
+        **kwargs: Any,
     ) -> AsyncIterator[StructuredResponse]:
         config = kwargs.pop("config", {})
 
@@ -66,7 +74,7 @@ class GoogleStructuredClient(BaseStructuredClient):
 
         last_usage_metadata = None
         has_yielded_content = False
-        
+
         async for chunk in self.client.aio.models.generate_content_stream(
             model=self.model_name,
             contents=prompt,
@@ -75,7 +83,7 @@ class GoogleStructuredClient(BaseStructuredClient):
             # Track usage metadata
             if hasattr(chunk, "usage_metadata") and chunk.usage_metadata:
                 last_usage_metadata = chunk.usage_metadata
-            
+
             # When using structured output, Google returns the parsed object directly
             if hasattr(chunk, "parsed") and chunk.parsed:
                 has_yielded_content = True

--- a/src/celeste_structured_output/providers/openai.py
+++ b/src/celeste_structured_output/providers/openai.py
@@ -1,5 +1,9 @@
 from typing import Any, AsyncIterator, List, Optional, get_origin
 
+from celeste_client.base import BaseStructuredClient
+from celeste_client.core.config import OPENAI_API_KEY
+from celeste_client.core.enums import OpenAIStructuredModel, StructuredOutputProvider
+from celeste_client.core.types import AIResponse, AIUsage
 from openai import AsyncOpenAI
 from openai.types.chat import (
     ChatCompletionMessageParam,
@@ -7,11 +11,6 @@ from openai.types.chat import (
     ChatCompletionUserMessageParam,
 )
 from pydantic import BaseModel, create_model
-
-from celeste_client.base import BaseStructuredClient
-from celeste_client.core.config import OPENAI_API_KEY
-from celeste_client.core.enums import StructuredOutputProvider, OpenAIStructuredModel
-from celeste_client.core.types import AIResponse, AIUsage
 
 
 class OpenAIClient(BaseStructuredClient):
@@ -34,7 +33,10 @@ class OpenAIClient(BaseStructuredClient):
         )
 
     async def generate_content(
-        self, prompt: str, response_schema: Optional[BaseModel] = None, **kwargs: Any
+        self,
+        prompt: str,
+        response_schema: Optional[type[BaseModel]] = None,
+        **kwargs: Any,
     ) -> AIResponse:
         messages: List[ChatCompletionMessageParam] = [
             ChatCompletionUserMessageParam(role="user", content=prompt)
@@ -87,7 +89,10 @@ class OpenAIClient(BaseStructuredClient):
         )
 
     async def stream_generate_content(
-        self, prompt: str, response_schema: Optional[BaseModel] = None, **kwargs: Any
+        self,
+        prompt: str,
+        response_schema: Optional[type[BaseModel]] = None,
+        **kwargs: Any,
     ) -> AsyncIterator[AIResponse]:
         messages: List[ChatCompletionMessageParam] = [
             ChatCompletionUserMessageParam(role="user", content=prompt)


### PR DESCRIPTION
## Summary
- allow `response_schema` as type of BaseModel
- sort imports and clean formatting
- fix example formatting

## Testing
- `ruff check example.py src/celeste_structured_output/__init__.py src/celeste_structured_output/base.py src/celeste_structured_output/providers/google.py src/celeste_structured_output/providers/openai.py`

------
https://chatgpt.com/codex/tasks/task_e_688b5c7ce544832c841cb3cbc42b5552