### PR TITLE
Add HuggingFace structured output client

### DIFF
--- a/src/celeste_structured_output/__init__.py
+++ b/src/celeste_structured_output/__init__.py
@@ -5,12 +5,14 @@ Celeste AI Client - Minimal predefinition AI communication for Alita agents.
 from typing import Any, Union
 
 from .base import BaseStructuredClient
-from .core import StructuredResponse, StructuredOutputProvider
+from .core import StructuredOutputProvider, StructuredResponse
 
 __version__ = "0.1.0"
 
 
-def create_structured_client(provider: Union[StructuredOutputProvider, str], **kwargs: Any) -> BaseStructuredClient:
+def create_structured_client(
+    provider: Union[StructuredOutputProvider, str], **kwargs: Any
+) -> BaseStructuredClient:
     if isinstance(provider, str):
         provider = StructuredOutputProvider(provider)
 
@@ -23,6 +25,11 @@ def create_structured_client(provider: Union[StructuredOutputProvider, str], **k
         from .providers.openai import OpenAIClient
 
         return OpenAIClient(**kwargs)
+
+    if provider == StructuredOutputProvider.HUGGINGFACE:
+        from .providers.huggingface import HuggingFaceStructuredClient
+
+        return HuggingFaceStructuredClient(**kwargs)
 
     if provider == StructuredOutputProvider.MISTRAL:
         from .providers.mistral import MistralClient
@@ -41,5 +48,5 @@ __all__ = [
     "create_structured_client",
     "BaseStructuredClient",
     "StructuredOutputProvider",
-    "StructuredResponse"
+    "StructuredResponse",
 ]

--- a/src/celeste_structured_output/core/enums.py
+++ b/src/celeste_structured_output/core/enums.py
@@ -10,6 +10,11 @@ class StructuredOutputProvider(Enum):
 
     GOOGLE = "google"
     OPENAI = "openai"
+    MISTRAL = "mistral"
+    ANTHROPIC = "anthropic"
+    HUGGINGFACE = "huggingface"
+    OLLAMA = "ollama"
+
 
 class GoogleStructuredModel(Enum):
     """Google model enumeration for provider-specific model selection."""
@@ -43,3 +48,12 @@ class AnthropicStructuredModel(Enum):
     CLAUDE_4_SONNET = "claude-sonnet-4-20250514"
     CLAUDE_4_OPUS = "claude-opus-4-20250514"
 
+
+class HuggingFaceModel(Enum):
+    """Hugging Face model enumeration for provider-specific model selection."""
+
+    GEMMA_2_2B = "google/gemma-2-2b-it"
+    META_LLAMA_3_1_8B = "meta-llama/Meta-Llama-3.1-8B-Instruct"
+    MICROSOFT_PHI_4 = "microsoft/phi-4"
+    QWEN_2_5_7B_1M = "Qwen/Qwen2.5-7B-Instruct-1M"
+    DEEPSEEK_R1 = "deepseek-ai/DeepSeek-R1"


### PR DESCRIPTION
## Summary
- extend `StructuredOutputProvider` enum for more providers
- add `HuggingFaceModel` enumeration
- create `HuggingFaceStructuredClient` implementing structured output
- wire provider through `create_structured_client`
- silence mypy warnings in provider modules

## Testing
- `pre-commit run --files src/celeste_structured_output/core/enums.py src/celeste_structured_output/providers/huggingface.py src/celeste_structured_output/__init__.py src/celeste_structured_output/providers/google.py`

------
https://chatgpt.com/codex/tasks/task_e_688cc66a642c832cb3372b7988e2acac