### PR TITLE
Add Mistral structured output support

### DIFF
--- a/src/celeste_structured_output/__init__.py
+++ b/src/celeste_structured_output/__init__.py
@@ -5,12 +5,14 @@ Celeste AI Client - Minimal predefinition AI communication for Alita agents.
 from typing import Any, Union
 
 from .base import BaseStructuredClient
-from .core import StructuredResponse, StructuredOutputProvider
+from .core import StructuredOutputProvider, StructuredResponse
 
 __version__ = "0.1.0"
 
 
-def create_structured_client(provider: Union[StructuredOutputProvider, str], **kwargs: Any) -> BaseStructuredClient:
+def create_structured_client(
+    provider: Union[StructuredOutputProvider, str], **kwargs: Any
+) -> BaseStructuredClient:
     if isinstance(provider, str):
         provider = StructuredOutputProvider(provider)
 
@@ -25,9 +27,9 @@ def create_structured_client(provider: Union[StructuredOutputProvider, str], **k
         return OpenAIClient(**kwargs)
 
     if provider == StructuredOutputProvider.MISTRAL:
-        from .providers.mistral import MistralClient
+        from .providers.mistral import MistralStructuredClient
 
-        return MistralClient(**kwargs)
+        return MistralStructuredClient(**kwargs)
 
     if provider == StructuredOutputProvider.ANTHROPIC:
         from .providers.anthropic import AnthropicClient

--- a/src/celeste_structured_output/core/enums.py
+++ b/src/celeste_structured_output/core/enums.py
@@ -10,6 +10,7 @@ class StructuredOutputProvider(Enum):
 
     GOOGLE = "google"
     OPENAI = "openai"
+    MISTRAL = "mistral"
 
 class GoogleStructuredModel(Enum):
     """Google model enumeration for provider-specific model selection."""

--- a/src/celeste_structured_output/providers/mistral.py
+++ b/src/celeste_structured_output/providers/mistral.py
@@ -1,21 +1,30 @@
+from __future__ import annotations
+
+import json
 from typing import Any, AsyncIterator, Optional
 
 from mistralai import Mistral
+from mistralai.extra.utils.response_format import pydantic_model_from_json
+from pydantic import BaseModel
 
-from celeste_client.base import BaseStructuredClient
-from celeste_client.core.config import MISTRAL_API_KEY
-from celeste_client.core.enums import StructuredOutputProvider, MistralModel
-from celeste_client.core.types import AIResponse, AIUsage
+from ..base import BaseStructuredClient
+from ..core.config import MISTRAL_API_KEY
+from ..core.enums import (
+    MistralStructuredModel as MistralModel,
+)
+from ..core.enums import (
+    StructuredOutputProvider,
+)
+from ..core.types import AIUsage, StructuredResponse
 
 
-class MistralClient(BaseStructuredClient):
+class MistralStructuredClient(BaseStructuredClient):
     def __init__(
-        self, model: str = MistralModel.SMALL_LATEST.value, **kwargs: Any
+        self, model: str | MistralModel = MistralModel.SMALL_LATEST, **kwargs: Any
     ) -> None:
         super().__init__(**kwargs)
-
         self.client = Mistral(api_key=MISTRAL_API_KEY)
-        self.model_name = model
+        self.model_name = model.value if isinstance(model, MistralModel) else model
 
     def format_usage(self, usage_data: Any) -> Optional[AIUsage]:
         """Convert Mistral usage data to AIUsage."""
@@ -27,53 +36,61 @@ class MistralClient(BaseStructuredClient):
             total_tokens=getattr(usage_data, "total_tokens", 0),
         )
 
-    async def generate_content(self, prompt: str, **kwargs: Any) -> AIResponse:
-        response = await self.client.chat.complete_async(
+    async def generate_content(
+        self, prompt: str, response_schema: type[BaseModel], **kwargs: Any
+    ) -> StructuredResponse:
+        response = await self.client.chat.parse_async(
+            response_format=response_schema,
             model=self.model_name,
             messages=[{"role": "user", "content": prompt}],
             **kwargs,
         )
 
-        # Extract usage information if available
-        usage = self.format_usage(
-            response.usage if hasattr(response, "usage") else None
-        )
+        usage = self.format_usage(getattr(response, "usage", None))
+        content = None
+        if response.choices and response.choices[0].message:
+            content = response.choices[0].message.parsed
 
-        return AIResponse(
-            content=response.choices[0].message.content,
+        return StructuredResponse(
+            content=content,
             usage=usage,
             provider=StructuredOutputProvider.MISTRAL,
             metadata={"model": self.model_name},
         )
 
     async def stream_generate_content(
-        self, prompt: str, **kwargs: Any
-    ) -> AsyncIterator[AIResponse]:
-        response = await self.client.chat.stream_async(
+        self, prompt: str, response_schema: type[BaseModel], **kwargs: Any
+    ) -> AsyncIterator[StructuredResponse]:
+        stream = await self.client.chat.parse_stream_async(
+            response_format=response_schema,
             model=self.model_name,
             messages=[{"role": "user", "content": prompt}],
             **kwargs,
         )
 
+        buffer = ""
         usage_data = None
-        async for chunk in response:
-            # Yield content chunks
-            if chunk.data.choices[0].delta.content:
-                yield AIResponse(
-                    content=chunk.data.choices[0].delta.content,
-                    provider=StructuredOutputProvider.MISTRAL,
-                    metadata={"model": self.model_name, "is_stream_chunk": True},
-                )
+        async for chunk in stream:
+            if chunk.data.choices and chunk.data.choices[0].delta.content:
+                buffer += chunk.data.choices[0].delta.content
+            if chunk.data.usage:
+                usage_data = chunk.data.usage
 
-            # Check for usage data in the chunk
-            if hasattr(chunk.data, "usage") and chunk.data.usage:
-                usage_data = self.format_usage(chunk.data.usage)
+        if buffer:
+            content = pydantic_model_from_json(
+                json.loads(buffer),
+                response_schema,
+            )
+            yield StructuredResponse(
+                content=content,
+                provider=StructuredOutputProvider.MISTRAL,
+                metadata={"model": self.model_name, "is_stream_chunk": True},
+            )
 
-        # Yield final usage data if available
         if usage_data:
-            yield AIResponse(
-                content="",
-                usage=usage_data,
+            yield StructuredResponse(
+                content=None,
+                usage=self.format_usage(usage_data),
                 provider=StructuredOutputProvider.MISTRAL,
                 metadata={"model": self.model_name, "is_final_usage": True},
             )


### PR DESCRIPTION
## Summary
- add MISTRAL option to `StructuredOutputProvider`
- implement `MistralStructuredClient` for structured output
- update factory method to use new client

## Testing
- `ruff check src/celeste_structured_output/providers/mistral.py`
- `ruff check src/celeste_structured_output/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_688cc64e1fe4832c8eb10934964c92f6