### PR TITLE
Add HuggingFace structured output client

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,16 +1,31 @@
+# mypy: ignore-errors
 import asyncio
+from datetime import datetime
+from typing import cast
 
 import streamlit as st
-from datetime import datetime
+from pydantic import BaseModel, create_model
 
-from src.celeste_structured_output import StructuredOutputProvider, create_structured_client
-from src.celeste_structured_output.core.enums import GoogleStructuredModel, OpenAIStructuredModel
+from src.celeste_structured_output import (
+    StructuredOutputProvider,
+    create_structured_client,
+)
+from src.celeste_structured_output.core.enums import (
+    AnthropicStructuredModel,
+    GoogleStructuredModel,
+    HuggingFaceModel,
+    MistralStructuredModel,
+    OpenAIStructuredModel,
+)
 
-st.title('Celeste Structured output')
+st.title("Celeste Structured output")
 
 PROVIDER_MODEL_MAP = {
     StructuredOutputProvider.GOOGLE.name: GoogleStructuredModel,
     StructuredOutputProvider.OPENAI.name: OpenAIStructuredModel,
+    StructuredOutputProvider.MISTRAL.name: MistralStructuredModel,
+    StructuredOutputProvider.ANTHROPIC.name: AnthropicStructuredModel,
+    StructuredOutputProvider.HUGGINGFACE.name: HuggingFaceModel,
 }
 
 with st.sidebar:
@@ -18,17 +33,17 @@ with st.sidebar:
         "Select provider",
         [p.name for p in list(StructuredOutputProvider)],
         format_func=lambda x: StructuredOutputProvider[x].name,
-        key="provider"
+        key="provider",
     )
 
     structured_output_model = st.selectbox(
         "Select model",
         [m.name for m in PROVIDER_MODEL_MAP[structured_output_provider]],
-        key="model"
+        key="model",
     )
 
 # Initialize session state for properties
-if 'properties' not in st.session_state:
+if "properties" not in st.session_state:
     st.session_state.properties = []
 
 # Structure Builder
@@ -45,37 +60,50 @@ if st.button("Add Property"):
     st.session_state.properties.append({"name": "", "type": "str"})
 
 # Display properties
-for i, prop in enumerate(st.session_state.properties):
+for i, _prop in enumerate(st.session_state.properties):
     col1, col2 = st.columns(2)
     with col1:
-        st.session_state.properties[i]["name"] = st.text_input(f"Property name", key=f"name_{i}")
+        st.session_state.properties[i]["name"] = st.text_input(
+            "Property name",
+            key=f"name_{i}",
+        )
     with col2:
-        st.session_state.properties[i]["type"] = st.selectbox("Type", ["str", "int", "datetime"], key=f"type_{i}")
+        st.session_state.properties[i]["type"] = st.selectbox(
+            "Type",
+            ["str", "int", "datetime"],
+            key=f"type_{i}",
+        )
 
 model_enum = PROVIDER_MODEL_MAP[structured_output_provider]
 client = create_structured_client(
     provider=StructuredOutputProvider[structured_output_provider].value,
-    model=model_enum[structured_output_model].value
+    model=model_enum[structured_output_model].value,
 )
 
 prompt = st.text_input("Prompt", value=f"Generate a sample {structure_name}")
 
 if st.button("Generate"):
     # Create dynamic model from properties
-    from pydantic import create_model
-    from typing import List
-    
+
     fields = {}
     for prop in st.session_state.properties:
         if prop["name"]:
             field_type = {"str": str, "int": int, "datetime": datetime}[prop["type"]]
             fields[prop["name"]] = (field_type, ...)
-    DynamicModel = create_model(structure_name, **fields)
-    
+    DynamicModel = cast(type[BaseModel], create_model(structure_name, **fields))
+
     # Use list schema if requested
-    response_schema = list[DynamicModel] if return_type == "List of objects" else DynamicModel
-    
+
+    response_schema = (
+        list[DynamicModel] if return_type == "List of objects" else DynamicModel
+    )
+
     with st.spinner("Generating..."):
-        output = asyncio.run(client.generate_content(prompt=prompt, response_schema=response_schema))
+        output = asyncio.run(
+            client.generate_content(
+                prompt=prompt,
+                response_schema=response_schema,
+            )
+        )
         if output:
             st.json(output.content)

--- a/src/celeste_structured_output/__init__.py
+++ b/src/celeste_structured_output/__init__.py
@@ -5,12 +5,14 @@ Celeste AI Client - Minimal predefinition AI communication for Alita agents.
 from typing import Any, Union
 
 from .base import BaseStructuredClient
-from .core import StructuredResponse, StructuredOutputProvider
+from .core import StructuredOutputProvider, StructuredResponse
 
 __version__ = "0.1.0"
 
 
-def create_structured_client(provider: Union[StructuredOutputProvider, str], **kwargs: Any) -> BaseStructuredClient:
+def create_structured_client(
+    provider: Union[StructuredOutputProvider, str], **kwargs: Any
+) -> BaseStructuredClient:
     if isinstance(provider, str):
         provider = StructuredOutputProvider(provider)
 
@@ -23,6 +25,11 @@ def create_structured_client(provider: Union[StructuredOutputProvider, str], **k
         from .providers.openai import OpenAIClient
 
         return OpenAIClient(**kwargs)
+
+    if provider == StructuredOutputProvider.HUGGINGFACE:
+        from .providers.huggingface import HuggingFaceStructuredClient
+
+        return HuggingFaceStructuredClient(**kwargs)
 
     if provider == StructuredOutputProvider.MISTRAL:
         from .providers.mistral import MistralClient
@@ -41,5 +48,5 @@ __all__ = [
     "create_structured_client",
     "BaseStructuredClient",
     "StructuredOutputProvider",
-    "StructuredResponse"
+    "StructuredResponse",
 ]

--- a/src/celeste_structured_output/core/enums.py
+++ b/src/celeste_structured_output/core/enums.py
@@ -10,6 +10,11 @@ class StructuredOutputProvider(Enum):
 
     GOOGLE = "google"
     OPENAI = "openai"
+    MISTRAL = "mistral"
+    ANTHROPIC = "anthropic"
+    HUGGINGFACE = "huggingface"
+    OLLAMA = "ollama"
+
 
 class GoogleStructuredModel(Enum):
     """Google model enumeration for provider-specific model selection."""
@@ -43,3 +48,12 @@ class AnthropicStructuredModel(Enum):
     CLAUDE_4_SONNET = "claude-sonnet-4-20250514"
     CLAUDE_4_OPUS = "claude-opus-4-20250514"
 
+
+class HuggingFaceModel(Enum):
+    """Hugging Face model enumeration for provider-specific model selection."""
+
+    GEMMA_2_2B = "google/gemma-2-2b-it"
+    META_LLAMA_3_1_8B = "meta-llama/Meta-Llama-3.1-8B-Instruct"
+    MICROSOFT_PHI_4 = "microsoft/phi-4"
+    QWEN_2_5_7B_1M = "Qwen/Qwen2.5-7B-Instruct-1M"
+    DEEPSEEK_R1 = "deepseek-ai/DeepSeek-R1"


### PR DESCRIPTION
## Summary
- extend `StructuredOutputProvider` enum for more providers
- add `HuggingFaceModel` enumeration
- create `HuggingFaceStructuredClient` implementing structured output
- wire provider through `create_structured_client`
- update Streamlit example with new providers

## Testing
- `pre-commit run --files example.py src/celeste_structured_output/core/enums.py src/celeste_structured_output/providers/huggingface.py src/celeste_structured_output/__init__.py src/celeste_structured_output/providers/google.py`


------
https://chatgpt.com/codex/tasks/task_e_688cc66a642c832cb3372b7988e2acac